### PR TITLE
インストール可能なアプリケーションの一覧を確認できる画面を追加

### DIFF
--- a/Candy.Client/Candy/Candy.csproj
+++ b/Candy.Client/Candy/Candy.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Utilities\DisposableExtensions.cs" />
     <Compile Include="Models\UpdateSummary.cs" />
     <Compile Include="Utilities\TaskEx.cs" />
+    <Compile Include="ViewModels\InstallableApplicationsViewModel.cs" />
     <Compile Include="ViewModels\HelpViewModel.cs" />
     <Compile Include="ViewModels\SettingsViewModel.cs" />
     <Compile Include="ViewModels\WebsiteViewModel.cs" />
@@ -175,6 +176,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Views\InstallableApplicationsWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Views\HelpWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -196,6 +201,9 @@
       <DependentUpon>SettingsFlyout.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\Converters\InvertBooleanConverter.cs" />
+    <Compile Include="Views\InstallableApplicationsWindow.xaml.cs">
+      <DependentUpon>InstallableApplicationsWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\HelpWindow.xaml.cs">
       <DependentUpon>HelpWindow.xaml</DependentUpon>
     </Compile>

--- a/Candy.Client/Candy/Models/ApplicationManager.cs
+++ b/Candy.Client/Candy/Models/ApplicationManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Configuration;
 using System.IO;
 using System.IO.Compression;
@@ -44,6 +45,13 @@ namespace Candy.Client.Models
         public ObservableSynchronizedCollection<InstalledApplication> Applications
         {
             get { return _applications; }
+        }
+        /// <summary>
+        /// インストール可能なアプリケーションの一覧を取得します。
+        /// </summary>
+        internal IReadOnlyList<ApplicationMetadata> InstallableApplications
+        {
+            get { return new ReadOnlyCollection<ApplicationMetadata>(_appInfo.Applications); }
         }
         /// <summary>
         /// 構成情報を永続化するための <see cref="IStateRepository"/> を取得します。

--- a/Candy.Client/Candy/ViewModels/InstallableApplicationsViewModel.cs
+++ b/Candy.Client/Candy/ViewModels/InstallableApplicationsViewModel.cs
@@ -1,0 +1,21 @@
+﻿using Candy.Client.Models;
+using Livet;
+using System.Collections.Generic;
+
+namespace Candy.Client.ViewModels
+{
+    public class InstallableApplicationsViewModel : ViewModel
+    {
+        private readonly IReadOnlyList<ApplicationMetadata> _installableApplications;
+
+        public IReadOnlyList<ApplicationMetadata> InstallableApplications
+        {
+            get { return _installableApplications; }
+        }
+
+        public InstallableApplicationsViewModel(IReadOnlyList<ApplicationMetadata> installableApplications)
+        {
+            _installableApplications = installableApplications;
+        }
+    }
+}

--- a/Candy.Client/Candy/ViewModels/MainWindowViewModel.cs
+++ b/Candy.Client/Candy/ViewModels/MainWindowViewModel.cs
@@ -61,6 +61,10 @@ namespace Candy.Client.ViewModels
         /// <summary>
         /// 
         /// </summary>
+        public ReactiveCommand ShowInstallableApplicationsCommand { get; private set; }
+        /// <summary>
+        /// 
+        /// </summary>
         public ReactiveCommand RegisterApplicationCommand { get; private set; }
         /// <summary>
         /// 
@@ -105,6 +109,9 @@ namespace Candy.Client.ViewModels
 
             ShowHelpCommand = new ReactiveCommand();
             ShowHelpCommand.Subscribe(_ => ShowHelp());
+
+            ShowInstallableApplicationsCommand = new ReactiveCommand();
+            ShowInstallableApplicationsCommand.Subscribe(_ => ShowInstallableApplications());
 
             RegisterApplicationCommand = IsProgressActive.Select(x => !x).ToReactiveCommand();
             RegisterApplicationCommand.Subscribe(_ => RegisterApplication());
@@ -163,6 +170,17 @@ namespace Candy.Client.ViewModels
             {
                 MessageKey = "ShowHelp",
                 TransitionViewModel = new HelpViewModel()
+            });
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        public void ShowInstallableApplications()
+        {
+            Messenger.Raise(new TransitionMessage
+            {
+                MessageKey = "ShowInstallableApplications",
+                TransitionViewModel = new InstallableApplicationsViewModel(_manager.InstallableApplications)
             });
         }
         /// <summary>

--- a/Candy.Client/Candy/Views/InstallableApplicationsWindow.xaml
+++ b/Candy.Client/Candy/Views/InstallableApplicationsWindow.xaml
@@ -1,0 +1,36 @@
+﻿<mahapps:MetroWindow x:Class="Candy.Client.Views.InstallableApplicationsWindow"
+                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+                     xmlns:mahapps="http://metro.mahapps.com/winfx/xaml/controls"
+                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                     xmlns:viewModels="clr-namespace:Candy.Client.ViewModels"
+                     mc:Ignorable="d"
+                     d:DataContext="{d:DesignInstance viewModels:InstallableApplicationsViewModel}"
+                     ShowMinButton="False"
+                     GlowBrush="{StaticResource AccentColorBrush}"
+                     WindowStartupLocation="CenterOwner"
+                     Icon="/Candy;component/Resources/1447690281_christmas_5.ico"
+                     TitleCaps="False"
+                     Title="利用可能なアプリケーション" Height="550" Width="1000">
+    <Grid Margin="6">
+        <DataGrid AutoGenerateColumns="False" Name="dgApplication" 
+                CanUserAddRows="False" HeadersVisibility="Column"
+                ClipboardCopyMode="ExcludeHeader" SelectionMode="Single" SelectionUnit="Cell"
+                ItemsSource="{Binding InstallableApplications}" >
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="識別子" Binding="{Binding Path=Id}" IsReadOnly="True" Width="100" />
+                <DataGridTextColumn Header="アプリ名" Binding="{Binding Path=DisplayName}" IsReadOnly="True" Width="200" />
+                <DataGridTextColumn Header="開発者" Binding="{Binding Path=DeveloperName}" IsReadOnly="True" Width="120" />
+                <DataGridTextColumn Header="説明" Binding="{Binding Path=Definition}" IsReadOnly="True" Width="*" >
+                    <DataGridTextColumn.ElementStyle>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="TextWrapping"
+                                Value="Wrap" />
+                        </Style>
+                    </DataGridTextColumn.ElementStyle>
+                </DataGridTextColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</mahapps:MetroWindow>

--- a/Candy.Client/Candy/Views/InstallableApplicationsWindow.xaml.cs
+++ b/Candy.Client/Candy/Views/InstallableApplicationsWindow.xaml.cs
@@ -1,0 +1,15 @@
+﻿using MahApps.Metro.Controls;
+
+namespace Candy.Client.Views
+{
+    /// <summary>
+    /// InstallableApplicationsWindow.xaml の相互作用ロジック
+    /// </summary>
+    public partial class InstallableApplicationsWindow : MetroWindow
+    {
+        public InstallableApplicationsWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Candy.Client/Candy/Views/MainWindow.xaml
+++ b/Candy.Client/Candy/Views/MainWindow.xaml
@@ -24,6 +24,13 @@
     <mahapps:MetroWindow.RightWindowCommands>
         <mahapps:WindowCommands Visibility="{Binding ShowWindowRightCommands.Value, Converter={StaticResource BooleanToVisibilityConverter}}">
 
+            <Button Command="{Binding ShowInstallableApplicationsCommand}">
+                <Rectangle Fill="{Binding RelativeSource={RelativeSource AncestorType=Button}, Path=Foreground}" Width="14" Height="16">
+                    <Rectangle.OpacityMask>
+                        <VisualBrush Visual="{StaticResource appbar_list}" Stretch="Fill" />
+                    </Rectangle.OpacityMask>
+                </Rectangle>
+            </Button>
             <Button>
                 <i:Interaction.Triggers>
                     <i:EventTrigger EventName="Click">
@@ -70,6 +77,9 @@
         </l:InteractionMessageTrigger>
         <l:InteractionMessageTrigger MessageKey="ShowHelp" Messenger="{Binding Messenger}">
             <l:TransitionInteractionMessageAction WindowType="v:HelpWindow" Mode="Modal" InvokeActionOnlyWhenWindowIsActive="False" />
+        </l:InteractionMessageTrigger>
+        <l:InteractionMessageTrigger MessageKey="ShowInstallableApplications" Messenger="{Binding Messenger}">
+            <l:TransitionInteractionMessageAction WindowType="v:InstallableApplicationsWindow" Mode="Modal" InvokeActionOnlyWhenWindowIsActive="False" />
         </l:InteractionMessageTrigger>
     </i:Interaction.Triggers>
 


### PR DESCRIPTION
#12 
一覧画面からインストールできるようにするという話になっていましたが、変更箇所が小さく抑えるためにまずはインストール可能なアプリケーションの一覧を確認して識別子をコピーできる画面を追加しました。
![image](https://user-images.githubusercontent.com/6694347/179122825-f9fa4679-4ad7-4790-a235-25fcdaca8284.png)

