### PR TITLE
Candy と Candy.Updater で配置フォルダを分割し、モジュールの依存関係をなくすことで正常に Candy を更新できる状態にする

### DIFF
--- a/Candy.Client/Candy.Updater/App.config
+++ b/Candy.Client/Candy.Updater/App.config
@@ -3,4 +3,7 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+    <runtime>
+        <probing privatePath="bin" />
+    </runtime>
 </configuration>

--- a/Candy.Client/Candy.Updater/App.config
+++ b/Candy.Client/Candy.Updater/App.config
@@ -4,6 +4,12 @@
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
     <runtime>
-        <probing privatePath="bin" />
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <probing privatePath="bin" />
+            <dependentAssembly>
+                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+            </dependentAssembly>
+        </assemblyBinding>
     </runtime>
 </configuration>

--- a/Candy.Client/Candy.Updater/Candy.Updater.csproj
+++ b/Candy.Client/Candy.Updater/Candy.Updater.csproj
@@ -23,19 +23,21 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\bin\Debug\</OutputPath>
+    <OutputPath>..\bin\Debug\Updater\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\bin\Release\</OutputPath>
+    <OutputPath>..\bin\Release\Updater\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>
@@ -115,6 +117,11 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>if not exist "$(TargetDir)bin" (mkdir "$(TargetDir)bin")
+move "$(TargetDir)*.dll" "$(TargetDir)\bin" 2&gt;nul
+del "$(TargetDir)*.xml"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Candy.Client/Candy.Updater/CandyUpdater.cs
+++ b/Candy.Client/Candy.Updater/CandyUpdater.cs
@@ -122,7 +122,7 @@ namespace Candy.Updater
                 var destPath = Path.Combine(targetDirectoryPath, entry.FullName);
 
                 // 自分自身の場合は確実に書き込み失敗するため無視する（現状は Candy.exe 側で書き換えてもらう想定。将来的には自身で自身をアップデートできるようにしたい＝シャルロッテ方式）
-                if (String.Equals(Assembly.GetEntryAssembly().Location, destPath)) continue;
+                if (entry.FullName.StartsWith(@"Updater/", StringComparison.OrdinalIgnoreCase)) continue;
 
                 var destFile = new FileInfo(destPath);
                 var destDir = new DirectoryInfo(Path.GetDirectoryName(destPath));

--- a/Candy.Client/Candy/App.config
+++ b/Candy.Client/Candy/App.config
@@ -8,11 +8,11 @@
     </startup>
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <probing privatePath="bin" />
             <dependentAssembly>
                 <assemblyIdentity name="Livet" publicKeyToken="b0b1d3f711ef38cb" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
             </dependentAssembly>
-            <probing privatePath="bin" />
             <dependentAssembly>
                 <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />

--- a/Candy.Client/Candy/Candy.csproj
+++ b/Candy.Client/Candy/Candy.csproj
@@ -32,15 +32,17 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <DocumentationFile>
     </DocumentationFile>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\1447690281_christmas_5.ico</ApplicationIcon>
@@ -286,7 +288,8 @@
   <PropertyGroup>
     <PostBuildEvent>if not exist "$(TargetDir)bin" (mkdir "$(TargetDir)bin")
 move "$(TargetDir)*.dll" "$(TargetDir)\bin" 2&gt;nul
-copy "$(TargetDir)bin\Newtonsoft.Json.dll" "$(TargetDir)Newtonsoft.Json.dll"</PostBuildEvent>
+rd /s /q "$(TargetDir)ja"
+del "$(TargetDir)*.xml"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Candy.Client/Candy/Models/ApplicationModel/CandyApplication.cs
+++ b/Candy.Client/Candy/Models/ApplicationModel/CandyApplication.cs
@@ -93,7 +93,7 @@ namespace Candy.Client.Models
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "Updater/Candy.Updater.exe",
+                    FileName = @"Updater\Candy.Updater.exe",
                     Arguments = arguments,
                 },
             };

--- a/Candy.Client/Candy/Properties/AssemblyInfo.cs
+++ b/Candy.Client/Candy/Properties/AssemblyInfo.cs
@@ -53,4 +53,4 @@ using System.Windows;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 
-[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyFileVersion("0.3.0.0")]

--- a/Candy.Client/Candy/Properties/AssemblyInfo.cs
+++ b/Candy.Client/Candy/Properties/AssemblyInfo.cs
@@ -53,4 +53,4 @@ using System.Windows;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 
-[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyFileVersion("0.3.1.0")]


### PR DESCRIPTION
#32 にて Newtonsoft.Json.dll の更新を実施したが、現状の更新では既存環境への配布が失敗する。
下記のようにフォルダを分割することで正常に更新できるように修正する。
![image](https://github.com/Wabyon/Candy/assets/6694347/f4d1a5bd-6056-46cf-92fc-4bc1fff6192f)
