### PR TITLE
#36 で依存関係を分離した際の不具合を修正

### DIFF
--- a/Candy.Client/Candy.Updater/CandyUpdater.cs
+++ b/Candy.Client/Candy.Updater/CandyUpdater.cs
@@ -116,8 +116,8 @@ namespace Candy.Updater
         }
         private static async Task UpdateFilesAsync(ZipArchive archive, string targetDirectoryPath)
         {
-            // Length > 0 でファイル（非フォルダ）にしぼる（で正しいのか？）
-            foreach (var entry in archive.Entries.Where(x => x.Length > 0))
+            //フォルダは除外
+            foreach (var entry in archive.Entries.Where(x => x.Name != string.Empty))
             {
                 var destPath = Path.Combine(targetDirectoryPath, entry.FullName);
 

--- a/Candy.Client/Candy/Models/ApplicationModel/CandyApplication.cs
+++ b/Candy.Client/Candy/Models/ApplicationModel/CandyApplication.cs
@@ -70,7 +70,8 @@ namespace Candy.Client.Models
             {
                 // Updater 関連は本体で書き換える(dllの依存が共通している場合、上書きできないため)
                 foreach (var entry in archive.Entries
-                    .Where(r => r.FullName.StartsWith(@"Updater/", StringComparison.OrdinalIgnoreCase)))
+                    .Where(x => x.Name != string.Empty) //フォルダは除外
+                    .Where(x => x.FullName.StartsWith(@"Updater/", StringComparison.OrdinalIgnoreCase)))
                 {
                     // ディレクトリが存在しない場合はファイル作成時に例外となる
                     Directory.CreateDirectory(Path.GetDirectoryName(entry.FullName));

--- a/Candy.Client/Candy/Models/ApplicationModel/InstalledApplication.cs
+++ b/Candy.Client/Candy/Models/ApplicationModel/InstalledApplication.cs
@@ -188,7 +188,7 @@ namespace Candy.Client.Models
                 EnableRaisingEvents = true,
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "Candy.Updater.exe",
+                    FileName = @"Updater\Candy.Updater.exe",
                     Arguments = arguments,
                 },
             };


### PR DESCRIPTION
・Zip解凍時のフォルダ判定手法を修正（サイズ0のファイルが除外されることを回避）
・Candy が Updater モジュールを解凍する場合、フォルダが含まれると更新に失敗する不具合の修正
・Candy 以外のアプリケーションの更新ができない不具合の修正